### PR TITLE
query operator as lowercase to escape casesensetive troubles.

### DIFF
--- a/src/DSL/QueryBuilder.php
+++ b/src/DSL/QueryBuilder.php
@@ -279,7 +279,7 @@ trait QueryBuilder
 
             return ['match' => [$field => $value]];
         } else {
-            $operator = key($value);
+            $operator = strtolower(key($value));
             $operand = current($value);
             $queryPart = [];
 


### PR DESCRIPTION
Hi @pdphilip, I have got issue when using your extension together with [Laravel lighthouse](https://github.com/nuwave/lighthouse) extension - it makes query builder with upper case operators (eg. `LIKE`) but your extension allows only  lower case operators. 
So I added a hotfix to convert all operators to lowercase. And it solves my problem.

I'm not sure which one of extensions  better to apply this fix, but maybe this hotfix would help to someone else escape such troubles in future. 

Thank you!