### PR TITLE
Fix when first insert value is array

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -155,7 +155,7 @@ class Builder extends BaseBuilder
             return true;
         }
 
-        if (!is_array(reset($values))) {
+        if (!array_is_list($values)) {
             $values = [$values];
         }
 


### PR DESCRIPTION
@pdphilip hello, 

thank you merge my previous PR. I faced one issue in insert flow. For example my index has next mapping:
```php
'field_foo' => [
    'type' => 'text'
],
'field_bar' => [
    'type' => 'text'
],
```
If I insert in this way:
```php
$index = new MyIndexModel();
$index->fill(['field_bar' => 'Bar value', 'field_foo' => ['Foo value 1', 'Foo value 2']])->save();
```
It works. But if I use next way:
```php
$index = new MyIndexModel();
$index->fill(['field_foo' => ['Foo value 1', 'Foo value 2'], 'field_bar' => 'Bar value'])->save();
```
It doesn't work, because first value is array and current insert starts use every value like independent inserted doc.
I changed it to check `array_is_list`  - looks it solved the issue. There is I see just one problem - this function appeared after PHP 8.0, but I saw that last version of your lib supports Laravel upper then 10.0 (which needed PHP 8.0+)