### PR TITLE
Update Morphs Blueprints for Laravel ^12.23 Compatibility

### DIFF
--- a/src/Schema/ManagesDefaultMigrations.php
+++ b/src/Schema/ManagesDefaultMigrations.php
@@ -249,7 +249,7 @@ trait ManagesDefaultMigrations
     /**
      * {@inheritdoc}
      */
-    public function morphs($name, $indexName = null): void
+    public function morphs($name, $indexName = null, $after = null): void
     {
         $this->keyword("{$name}_type");
         $this->keyword("{$name}_id");
@@ -390,17 +390,17 @@ trait ManagesDefaultMigrations
     /**
      * {@inheritdoc}
      */
-    public function ulidMorphs($name, $indexName = null): void
+    public function ulidMorphs($name, $indexName = null, $after = null): void
     {
-        $this->morphs($name, $indexName);
+        $this->morphs($name, $indexName, $after);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function uuidMorphs($name, $indexName = null): void
+    public function uuidMorphs($name, $indexName = null, $after = null): void
     {
-        $this->morphs($name, $indexName);
+        $this->morphs($name, $indexName, $after);
     }
 
     /**


### PR DESCRIPTION
I noticed my migrations began failing with an incompatible declaration error:

```
Declaration of PDPhilip\OpenSearch\Schema\ManagesDefaultMigrations::morphs($name, $indexNa
  me = null): void must be compatible with Illuminate\Database\Schema\Blueprint::morphs($nam
  e, $indexName = null, $after = null)
```

It appears the morphs type blueprints were updated to support an `$after` parameter in [a recent change](https://github.com/laravel/framework/pull/56613/files) that was bundled into the Laravel 12.23.0 release.