### PR TITLE
fix: return `LazyCollection` from `cursor()` to honor the Eloquent contract

### DIFF
--- a/src/Eloquent/Builder.php
+++ b/src/Eloquent/Builder.php
@@ -13,7 +13,7 @@ use Illuminate\Pagination\Cursor;
 use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Collection;
-use Iterator;
+use Illuminate\Support\LazyCollection;
 use PDPhilip\Elasticsearch\Data\MetaDTO;
 use PDPhilip\OpenSearch\Exceptions\BuilderException;
 use PDPhilip\OpenSearch\Exceptions\DynamicIndexException;
@@ -375,15 +375,17 @@ class Builder extends BaseEloquentBuilder
     }
 
     /**
-     * Get a generator for the given query.
+     * Get a lazy collection for the given query.
      *
-     * @return Iterator
+     * @return LazyCollection
      */
     public function cursor($scrollTimeout = '30s')
     {
-        foreach ($this->applyScopes()->query->cursor($scrollTimeout) as $record) {
-            yield $this->model->newFromBuilder($record);
-        }
+        return new LazyCollection(function () use ($scrollTimeout) {
+            foreach ($this->applyScopes()->query->cursor($scrollTimeout) as $record) {
+                yield $this->model->newFromBuilder($record);
+            }
+        });
     }
 
     /**

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -8,12 +8,12 @@ use Carbon\Carbon;
 use Closure;
 use DateTimeInterface;
 use Exception;
-use Generator;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Query\Builder as BaseBuilder;
 use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 use PDPhilip\Elasticsearch\Data\MetaDTO;
@@ -573,19 +573,21 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * Get a generator for the given query.
+     * Get a lazy collection for the given query.
      *
-     * @return Generator
+     * @return LazyCollection
      */
     public function cursor($scrollTimeout = '30s')
     {
-        if (is_null($this->columns)) {
-            $this->columns = ['*'];
-        }
+        return new LazyCollection(function () {
+            if (is_null($this->columns)) {
+                $this->columns = ['*'];
+            }
 
-        foreach ($this->connection->cursor($this->toCompiledQuery()) as $document) {
-            yield $this->processor->documentFromResult($this, $document);
-        }
+            foreach ($this->connection->cursor($this->toCompiledQuery()) as $document) {
+                yield $this->processor->documentFromResult($this, $document);
+            }
+        });
     }
 
     /**

--- a/src/Query/Processor.php
+++ b/src/Query/Processor.php
@@ -38,9 +38,17 @@ class Processor extends BaseProcessor
 
     /**
      * Get the raw OpenSearch response as an array
+     *
+     * Null is legitimate: only select, insert and aggregate processing assign
+     * a raw response, and the scroll behind cursor() runs none of them. Per-hit
+     * meta reaches MetaDTO through documentFromResult's extras either way.
      */
     public function getRawResponse(): array
     {
+        if ($this->rawResponse === null) {
+            return [];
+        }
+
         return is_array($this->rawResponse) ? $this->rawResponse : $this->rawResponse->asArray();
     }
 

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Str;
 use PDPhilip\Elasticsearch\Data\ModelMeta;
@@ -520,6 +521,60 @@ it('returns a chunkable lazy collection from cursor', function () {
 
     $chunkSizes = $cursor->chunk(2)->map(fn ($chunk) => $chunk->count())->all();
     expect($chunkSizes)->toBe([2, 1]);
+});
+
+it('cursors on a connection that has not run a query yet', function () {
+    User::insert([
+        ['name' => 'User 1'],
+        ['name' => 'User 2'],
+        ['name' => 'User 3'],
+    ]);
+
+    // A scroll populates no raw response, so a cursor that is the first query
+    // on its connection has no earlier select or insert to inherit one from.
+    DB::purge('opensearch');
+
+    $names = User::query()->orderBy('name.keyword')->cursor()->pluck('name')->all();
+
+    expect($names)->toBe(['User 1', 'User 2', 'User 3']);
+});
+
+it('keeps the cursor lazy, hydrating only what is consumed', function () {
+    User::insert(array_map(fn ($i) => ['name' => "User {$i}"], range(1, 10)));
+
+    $hydrated = 0;
+    User::retrieved(function () use (&$hydrated) {
+        $hydrated++;
+    });
+
+    $cursor = User::query()->orderBy('name.keyword')->cursor();
+
+    // Building the collection must not touch the cluster.
+    expect($hydrated)->toBe(0);
+
+    $taken = $cursor->take(3)->all();
+
+    // Three, not ten - an eagerly materialised collection would fail here while
+    // every other assertion about cursor() carried on passing.
+    expect($taken)->toHaveCount(3)
+        ->and($hydrated)->toBe(3);
+});
+
+it('re-runs the scroll when the cursor is iterated twice', function () {
+    User::insert([
+        ['name' => 'User 1'],
+        ['name' => 'User 2'],
+        ['name' => 'User 3'],
+    ]);
+
+    $cursor = User::query()->orderBy('name.keyword')->cursor();
+
+    // A bare generator throws "Cannot rewind a generator" on the second pass.
+    $first = $cursor->pluck('name')->all();
+    $second = $cursor->pluck('name')->all();
+
+    expect($first)->toBe(['User 1', 'User 2', 'User 3'])
+        ->and($second)->toBe($first);
 });
 
 it('tests truncate model', function () {

--- a/tests/ModelTest.php
+++ b/tests/ModelTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\LazyCollection;
 use Illuminate\Support\Str;
 use PDPhilip\Elasticsearch\Data\ModelMeta;
 use PDPhilip\OpenSearch\Connection;
@@ -504,6 +505,21 @@ it('tests cursor across many items', function () {
         $names[] = $cursor;
     }
     expect($names)->toHaveCount(15000);
+});
+
+it('returns a chunkable lazy collection from cursor', function () {
+    User::insert([
+        ['name' => 'User 1'],
+        ['name' => 'User 2'],
+        ['name' => 'User 3'],
+    ]);
+
+    $cursor = User::query()->orderBy('name.keyword')->cursor();
+
+    expect($cursor)->toBeInstanceOf(LazyCollection::class);
+
+    $chunkSizes = $cursor->chunk(2)->map(fn ($chunk) => $chunk->count())->all();
+    expect($chunkSizes)->toBe([2, 1]);
 });
 
 it('tests truncate model', function () {

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\LazyCollection;
 use PDPhilip\OpenSearch\Query\Builder;
 use PDPhilip\OpenSearch\Tests\Models\Item;
 use PDPhilip\OpenSearch\Tests\Models\User;
@@ -619,7 +620,7 @@ it('verifies cursor returns lazy collection and checks names', function () {
 
     $results = DB::table('items')->orderBy('name.keyword', 'asc')->cursor();
 
-    expect($results)->toBeInstanceOf(Generator::class);
+    expect($results)->toBeInstanceOf(LazyCollection::class);
     foreach ($results as $i => $result) {
         expect($result['name'])->toBe($data[$i]['name']);
     }

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -626,6 +626,34 @@ it('verifies cursor returns lazy collection and checks names', function () {
     }
 });
 
+it('chunks a query builder cursor directly, without iterating it', function () {
+    DB::table('items')->insert([
+        ['name' => 'fork'],
+        ['name' => 'spoon'],
+        ['name' => 'spork'],
+    ]);
+
+    // Chained straight off cursor() rather than iterated - the call shape that
+    // failed with "Call to undefined method Generator::chunk()".
+    $chunks = DB::table('items')->orderBy('name.keyword', 'asc')->cursor()->chunk(2);
+
+    expect($chunks->map->count()->all())->toBe([2, 1])
+        ->and($chunks->first()->pluck('name')->all())->toBe(['fork', 'spoon']);
+});
+
+it('cursors a query builder on a connection that has not run a query yet', function () {
+    DB::table('items')->insert([
+        ['name' => 'fork'],
+        ['name' => 'spoon'],
+    ]);
+
+    DB::purge('opensearch');
+
+    $names = DB::table('items')->orderBy('name.keyword', 'asc')->cursor()->pluck('name')->all();
+
+    expect($names)->toBe(['fork', 'spoon']);
+});
+
 it('increments each specified field by respective values', function () {
     DB::table('users')->insert([
         ['name' => 'John Doe', 'age' => 30, 'note' => 5],


### PR DESCRIPTION
## Problem

Both `cursor()` overrides in this package are generator functions, so they return a bare PHP `Generator`:

- `PDPhilip\OpenSearch\Query\Builder::cursor()` (docblock says `@return Generator`)
- `PDPhilip\OpenSearch\Eloquent\Builder::cursor()` (docblock says `@return Iterator`)

The framework methods they override both return an `Illuminate\Support\LazyCollection`:

- [`Illuminate\Database\Query\Builder::cursor()`](https://github.com/laravel/framework/blob/12.x/src/Illuminate/Database/Query/Builder.php) — `new LazyCollection(function () { yield ...; })`
- [`Illuminate\Database\Eloquent\Builder::cursor()`](https://github.com/laravel/framework/blob/12.x/src/Illuminate/Database/Eloquent/Builder.php)

Any consumer written against the framework contract breaks when the model is OpenSearch-backed. The most visible real-world casualty is **Laravel Nova bulk actions**: `Laravel\Nova\Http\Requests\ActionRequest::chunks()` unconditionally chains

```php
$this->toSelectedResourceQuery()->cursor()->chunk($count)
```

which fatals with:

```
Call to undefined method Generator::chunk()
```

on **every** Nova action executed against an OpenSearch-backed resource. The same applies to any userland code calling `chunk()`, `map()`, `filter()`, `remember()`, etc. on a cursor.

Notably, the existing test suite seems to agree about the intent — `tests/QueryBuilderTest.php` has a test literally named *"verifies cursor returns lazy collection and checks names"*, but it currently asserts `Generator::class`. This PR makes the name true.

## Fix

Wrap the existing scroll generators in `LazyCollection::make()` — the same idiom the framework itself uses. Nothing about the iteration changes:

- The scroll-based generator still does the fetching; `LazyCollection` is only the container handed to the caller.
- Laziness is preserved — the closure is invoked on first iteration, and documents are pulled from the scroll one at a time.
- As a bonus, the cursor becomes safely re-iterable (each iteration opens a fresh scroll), whereas a raw `Generator` throws `Cannot rewind a generator` on a second pass.

No native return type was added, so subclasses overriding `cursor()` are not affected.

## Tests

- Updated *"verifies cursor returns lazy collection and checks names"* to assert `LazyCollection::class` (matching its name).
- Added *"returns a chunkable lazy collection from cursor"* covering the Eloquent builder and the `cursor()->chunk()` call shape Nova uses, including a chunk-boundary case (3 documents, chunk size 2).

Full suite, Pint, and PHPStan pass locally against OpenSearch 3.3.0.

## Note

`pdphilip/laravel-elasticsearch` carries the identical `cursor()` implementations — happy to open a matching PR there if this one is accepted.
